### PR TITLE
Adding GNU sed check in deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Useful shiz for developing Unikorn.
 ## Prerequisites
 
 * GNU `make`
+* GNU `sed` (default on Linux, `brew install gnused` on MacOS)
 * `go`
 * `kubectl`
 * `jq`
@@ -32,7 +33,7 @@ A special `global.yaml` file allows global parameters to be set for all deployme
 The deploy command has the following flags that may be of use:
 
 * `-e <environment>` choose the environment to use defined in `~/.config/unikorn/${environment}` when looking up values files.
-* `-t` dump the deployment out as raw resources, useful for piping into `kubeclt diff -f -` to make sure nothing untoward has changed.
+* `-t` dump the deployment out as raw resources, useful for piping into `kubectl diff -f -` to make sure nothing untoward has changed.
 * `-p` do a production deployment using the actual helm repository, as opposed to the local source tree.
 
 ### restart

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Useful shiz for developing Unikorn.
 ## Prerequisites
 
 * GNU `make`
-* GNU `sed` (default on Linux, `brew install gnused` on MacOS)
 * `go`
 * `kubectl`
 * `jq`

--- a/deploy
+++ b/deploy
@@ -4,7 +4,14 @@
 # has been bumped, otherwise you will need to manually restart all
 # the pods with kubectl.
 #
-# NOTE: must be run from the compenent's root directory.
+# NOTE: must be run from the component's root directory.
+
+# Check if gsed is available for MacOS users, otherwise fallback to sed
+if command -v gsed &> /dev/null; then
+    SED_CMD="gsed"
+else
+    SED_CMD="sed"
+fi
 
 # Get the environemnt.
 ENVIRONMENT="local"
@@ -44,7 +51,7 @@ GIT_REPO=""
 if [[ -f go.mod ]]; then
 	GIT_REPO="$(head -n1 go.mod | awk '{print $2}')"
 elif [[ -f package.json ]]; then
-	GIT_REPO="$(jq -r .repository.url package.json | sed 's,http[s]\?://,,')"
+	GIT_REPO="$(jq -r .repository.url package.json | $SED_CMD 's,http[s]\?://,,')"
 fi
 GIT_ORG_NAME=$(echo -n "${GIT_REPO}" | cut -d '/' -f 2)
 GIT_REPO_NAME=$(echo -n "${GIT_REPO}" | cut -d '/' -f 3)

--- a/deploy
+++ b/deploy
@@ -6,12 +6,6 @@
 #
 # NOTE: must be run from the component's root directory.
 
-# Check if gsed is available for MacOS users, otherwise fallback to sed
-if command -v gsed &> /dev/null; then
-    SED_CMD="gsed"
-else
-    SED_CMD="sed"
-fi
 
 # Get the environemnt.
 ENVIRONMENT="local"
@@ -51,7 +45,7 @@ GIT_REPO=""
 if [[ -f go.mod ]]; then
 	GIT_REPO="$(head -n1 go.mod | awk '{print $2}')"
 elif [[ -f package.json ]]; then
-	GIT_REPO="$(jq -r .repository.url package.json | $SED_CMD 's,http[s]\?://,,')"
+	GIT_REPO="$(jq -r .repository.url package.json | sed -e 's,https://,,')"
 fi
 GIT_ORG_NAME=$(echo -n "${GIT_REPO}" | cut -d '/' -f 2)
 GIT_REPO_NAME=$(echo -n "${GIT_REPO}" | cut -d '/' -f 3)


### PR DESCRIPTION
GNU based sed is not available on MacOS by default and so the sed command that's used to strip out `http[s]\?` in the deploy script will fail as \? seems to just be ignored or is unsupported. Maybe there are flags that will make it work, but rather than writing hacky "if gnused :use these flags: else if BSD sed :use these flags:", it's just easier for everyone use GNU sed and move on with their lives.

See output below.

```
echo https://example.com | sed 's,http[s]\?://,,'
https://example.com

echo http://example.com | sed 's,http[s]\?://,,'
http://example.com

echo https://example.com | gsed 's,http[s]\?://,,'
example.com

echo http://example.com | gsed 's,http[s]\?://,,'
example.com
```


There is now a check at the start of the script to check for gsed. If found it'll use that, if not it'll revert to using sed.
Since the fallback option of `sed` would cause issuse for Mac users, there is also a new note in the README to install GNU sed.