### PR TITLE
Script portability fixes

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # All Unikorn components use the same build system, so can be built in a generic
 # manner.  This does the build and pushes it into KinD.

--- a/clean-images
+++ b/clean-images
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Removes any dangling docker images, or which there will be many.
 

--- a/deploy
+++ b/deploy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Deploys a unikorn component.  Will only work if the chart version
 # has been bumped, otherwise you will need to manually restart all

--- a/release
+++ b/release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # All Unikorn components use the same build system, so can be built in a generic
 # manner.  This releases a component.

--- a/restart
+++ b/restart
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Restarts a unikorn component.  Gets more hardcore than the deploy
 # command when you've not mdified anything that would cause a pod

--- a/ui-preview
+++ b/ui-preview
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Define the environment.
 # TODO: getopts

--- a/uv
+++ b/uv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for i in core identity region compute kubernetes ui; do
 	VERSION=$(helm -n "unikorn-${i}" ls -o json | jq -r .[0].app_version)


### PR DESCRIPTION
Invoke `bash` via `env` instead, in case `/bin/bash` doesn't exist.