### PR TITLE
Fix missing dir bug and updating README to more portable install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,5 @@ BINARIES := build \
 
 .PHONY: install
 install: $(BINARIES)
+	mkdir -p $(PREFIX)
 	for binary in $(BINARIES); do install -m 0755 $${binary} $(PREFIX); done

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ build && restart
 
 ## Installation
 
+`yq` is required, on mac, `brew install yq`
+
 Run:
 ```shell
 sudo make install PREFIX=/usr/local/bin

--- a/README.md
+++ b/README.md
@@ -77,12 +77,11 @@ build && restart
 ## Installation
 
 Run:
-
 ```shell
-make install
+sudo make install PREFIX=/usr/local/bin
 ```
 
-**NOTE**: This defaults to ~/bin, you can set `PREFIX` to modify this.
+**NOTE**: PREFIX defaults to ~/bin, and this is not in PATH for mac.
 
 ## Contribution
 


### PR DESCRIPTION
If directory is missing, make will now create it, rather than replacing files to the directory's name.

Updating readme as /usr/local/bin is standard for this kind of thing