### PR TITLE
Support Helm 4

### DIFF
--- a/build
+++ b/build
@@ -8,4 +8,4 @@
 CHART="$(ls charts)"
 CHART_META="charts/${CHART}/Chart.yaml"
 
-make images-kind-load VERSION="$(yq .version "${CHART_META}")"
+make images-kind-load VERSION="v$(yq .version "${CHART_META}")"

--- a/release
+++ b/release
@@ -7,7 +7,7 @@
 
 CHART="$(ls charts)"
 CHART_META="charts/${CHART}/Chart.yaml"
-TAG="$(yq .version "${CHART_META}")"
+TAG="v$(yq .version "${CHART_META}")"
 
 git tag "${TAG}"
 git push origin "${TAG}"

--- a/release.py
+++ b/release.py
@@ -82,7 +82,7 @@ class Component:
 
             m = re.match(r'(version|appVersion):', line)
             if m:
-                line = f'{m.group(1)}: {canonical_version(version)}\n'
+                line = f'{m.group(1)}: {canonical_version(version)[1:]}\n'
 
             lines.append(line)
 


### PR DESCRIPTION
Semver formats are now forced to be X.Y.Z, so where we use Chart.yaml as the source of truth for Go tags, which must be vX.Y.Z, we need to be careful!