### PR TITLE
New Release Process

### DIFF
--- a/release.py
+++ b/release.py
@@ -45,7 +45,13 @@ def canonical_version(version: semver.Version) -> str:
     """
     Returns the canonical verson, used by tags, from a semanic version.
     """
-    return f'v{version.major}.{version.minor}.{version.patch}{"-" + version.prerelease if version.prerelease else ""}'
+    return f'v{version.major}.{version.minor}.{version.patch}{"-" + version.prerelease if version.prerelease else ""}{"+" + version.build if version.build else ""}'
+
+def release_branch(version: semver.Version) -> str:
+    """
+    Returns the release branch for a semanic version in the form vMAJOR.MINOR.x.
+    """
+    return f'v{version.major}.{version.minor}.x'
 
 class Component:
     """
@@ -57,17 +63,36 @@ class Component:
         self.dependencies = dependencies if dependencies else []
         self.precommit_hook = precommit_hook
 
-    def validate(self) -> None:
+    def validate(self, version: semver.Version) -> None:
         """
         validates whether the git trees are in a sane state.
         TODO: check whether we are at the remote HEAD.
         """
         print(f"\033[32;1mValidating\033[0m {self.name} ...")
 
+
         with pushd(self.name):
+            # Ensure our view of the remote is up to date...
+            subprocess.check_call(['git', 'fetch', 'origin'])
+
+            rel_branch = release_branch(version)
+
+            # We either need to be on the release branch already...
             branch = subprocess.check_output(['git', 'branch', '--show-current']).decode('utf-8').strip()
-            if branch != 'main':
-                raise RuntimeError(f'component {self.name} is not checked out to main')
+            if branch != rel_branch:
+                # Or be an ancestor of main.
+                try:
+                    subprocess.check_call(['git', 'merge-base', '--is-ancestor', 'HEAD', 'main'])
+                except subprocess.CalledProcessError as exc:
+                    raise RuntimeError(f'component {self.name} is not checked out to an ancestor of main main or {rel_branch}') from exc
+
+                # If we are on main, create a new branch and push before we make any changes.
+                subprocess.check_call(['git', 'checkout', '-b', rel_branch])
+                subprocess.check_call(['git', 'push', 'origin', rel_branch])
+            else:
+                # Ensure that the remote is an ancestor of our local branch as we
+                # may have cherry-picked commits in it, and don't want to erase history!
+                subprocess.check_call(['git', 'merge-base', '--is-ancestor', f'origin/{rel_branch}', 'HEAD'])
 
     def _update_chart_contents(self, file: TextIO, version: semver.Version) -> str:
         """
@@ -135,7 +160,7 @@ class Component:
 
         with pushd(self.name):
             print("\033[1mUpdating Helm\033[0m ...")
-            matches = glob.glob('charts/**/Chart.yaml')
+            matches = glob.glob(f"charts/{self.name}/Chart.yaml")
             if len(matches) != 1:
                 raise RuntimeError(f'failed to find Chart.yaml for component {self.name}')
 
@@ -157,27 +182,37 @@ class Component:
                     self._update_openapi(matches[0], version)
                     subprocess.check_call(['make', 'validate'])
 
-                if self.precommit_hook:
-                    print("\033[1mCalling Precommit Hook\033[0m ...")
-                    self.precommit_hook()
+            if self.precommit_hook:
+                print("\033[1mCalling Precommit Hook\033[0m ...")
+                self.precommit_hook()
 
             branch = 'bump'
             tag = canonical_version(version)
             title = f'Version {tag}'
+            rel_branch = release_branch(version)
 
             print("\033[1mCommitting Update\033[0m ...")
             subprocess.check_call(['git', 'checkout', '-b', branch])
             subprocess.check_call(['git', 'add', '.'])
             subprocess.check_call(['git', 'commit', '-m', title])
             subprocess.check_call(['git', 'push', '-f', 'origin', branch])
-            subprocess.check_call(['gh', 'pr', 'create', '--head', branch, '--title', title, '--body', ''])
+            subprocess.check_call(['gh', 'pr', 'create', '--base', rel_branch, '--head', branch, '--fill'])
+
+            print("\033[1mPerforming Status Checks\033[0m ...")
+            # Make sure to give the status checks time to start...
+            # If it breaks here, then it's probably due to a change that isn't backards
+            # compatible.  You're probably best manually patching it for now and then
+            # finishing off the rest of this function by hand and continuing --from the
+            # next repository.
+            time.sleep(30)
+            subprocess.check_call(['gh', 'pr', 'checks', '--watch'])
 
             print("\033[1mMerge\033[0m ...")
             input("Please get the pull request approved and merged, then hit ENTER to continue")
 
             print("\033[1mRelease\033[0m ...")
-            subprocess.check_call(['git', 'checkout', 'main'])
-            subprocess.check_call(['git', 'pull'])
+            subprocess.check_call(['git', 'checkout', rel_branch])
+            subprocess.check_call(['git', 'pull', 'origin', rel_branch])
             subprocess.check_call(['git', 'tag', tag])
             subprocess.check_call(['git', 'push', 'origin', tag])
             subprocess.check_call(['git', 'branch', '-D', branch])
@@ -198,6 +233,9 @@ COMPONENTS = [
         Component('region', dependencies=['core', 'identity']),
         Component('compute', dependencies=['core', 'identity', 'region']),
         Component('kubernetes', dependencies=['core', 'identity', 'region']),
+        # If this fails, then someone has probably made a breaking API change
+        # that needs to be communicated to every possible client... Realistically
+        # that's not going to happen, so talk to the engineer responsible!
         Component('ui', precommit_hook=ui_npm_update),
 ]
 
@@ -206,7 +244,7 @@ def components_from(step: str) -> list[Component]:
     Returns all components from the given step
     """
 
-    if step == None:
+    if step is None:
         return COMPONENTS
 
     index = next((i for i, c in enumerate(COMPONENTS) if c.name == step), -1)
@@ -216,7 +254,8 @@ def components_from(step: str) -> list[Component]:
 
 class SemverNormalizeAction(argparse.Action):
     """
-    Semvers should start with 'v', unless you are python...
+    Some things (Go) mandate semvers as having a "v" prefix you can
+    use whatever you are comfortable with and we'll handle it!
     """
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         if nargs is not None:
@@ -244,7 +283,7 @@ def main():
     components = components_from(args.from_step)
 
     for component in components:
-        component.validate()
+        component.validate(version)
 
     for component in components:
         component.release(version)


### PR DESCRIPTION
Rather than stop everyone committing during a release window, which may involve several iterations of test and fix, this allows you to checkout a specific point on main to branch from, so it's totally divorced from upstream development.

If the repository is checked out to an ancestor of main it will create a release branch and push it to the upstream.

If it's already on the release branch (e.g. for release candidates) it will check that the remote release branch is an ancestor of the local one, assuming that you may have cherry picked some fixes into it, and ensures the remote can be fast forwarded.

Next it will create a pull request targeting the release branch (not main), which have been locked down in GitHub to require a pull request and all the goodness that entails e.g. tests, to ensure nothing has been cherry picked that is backwards incompatible or otherwise dodgy that would fall afoul of the CI pipelines and prevent the release from
    succeeding, which is a royal pain to unpick.